### PR TITLE
Cross-link the 2 indexes, add link to youtube channel

### DIFF
--- a/src/Flat index.md
+++ b/src/Flat index.md
@@ -116,3 +116,7 @@ Pratt, a London University PhD thesis of 1998.
 
 [Real-Time Programming and the Big Ideas of Computational Literacy](<../theses/Real-Time Programming and the Big Ideas of Computational Literacy (Hancock, MIT PhD, 2003).pdf>) -
 Chris Hancock, an MIT PhD thesis of 2003.
+
+## Videos
+
+The [Boxer Reconstruction Project youtube channel](https://www.youtube.com/channel/UCM6mpnjb75v3FFrxH4vKlWQ) has several videos.

--- a/src/Flat index.md
+++ b/src/Flat index.md
@@ -5,6 +5,8 @@ title: Flat index to the Boxer literature
 
 # A flat index to the Boxer literature
 
+See [Thematic index](<../Thematic index>) instead if you prefer  an overview of a selected subset.
+
 ## Boxer Papers
 
 [Notes on Friendly Computer Systems - MIT Logo Group Memo (diSessa, 1978)](<../papers/Notes on Friendly Computer Systems - MIT Logo Group Memo (diSessa, 1978).pdf>)

--- a/src/Thematic index.md
+++ b/src/Thematic index.md
@@ -7,6 +7,8 @@ title: Thematic index to the Boxer literature
 
 This partisan guide is prepared by Antranig Basman, and all editorial remarks are his unless otherwise noted.
 
+It focuses on selected papers, see [Flat index](<../Flat index>) for a complete list.
+
 ## Boxer's Design
 
 ### A Principled Design for an Integrated Computational Environment


### PR DESCRIPTION
First commit adds links between the 2 indexes.  While https://boxer-project.github.io/boxer-literature/
links to both indexes, it feels more immediately useful to send people directly to one of them (even the README does—it only links to Thematic Index!), but then the person is stuck in that index and won't even know more papers exist. So I think cross-linking the 2 index pages is helpful.

Second commit mentions https://www.youtube.com/channel/UCM6mpnjb75v3FFrxH4vKlWQ channel which appears to contain the only videos about Boxer on the net?

P.S. I see there was recently [Boxer Salon](https://2022.programming-conference.org/home/salon-2022#event-overview) :star_struck:, were any of the sessions recorded? :pray: :pray: 